### PR TITLE
fix para que no de error al calcular el cierre de ejercicio

### DIFF
--- a/account_fiscal_year_closing/models/account_fiscalyear_closing.py
+++ b/account_fiscal_year_closing/models/account_fiscalyear_closing.py
@@ -553,13 +553,13 @@ class AccountFiscalyearClosingMapping(models.Model):
 
     @api.model
     def create(self, vals):
-        if "dest_account_id" in vals:
+        if "dest_account_id" in vals and vals.get("dest_account_id"):
             vals["dest_account_id"] = vals["dest_account_id"][0]
         res = super(AccountFiscalyearClosingMapping, self).create(vals)
         return res
 
     def write(self, vals):
-        if "dest_account_id" in vals:
+        if "dest_account_id" in vals and vals.get("dest_account_id"):
             vals["dest_account_id"] = vals["dest_account_id"][0]
         res = super(AccountFiscalyearClosingMapping, self).write(vals)
         return res


### PR DESCRIPTION
no se debe pasar el parámetro de dest_account_id en el create ni en el write si dest_account_id viene vacío ya que esto hace que de un error al calcularse